### PR TITLE
Fixing bug

### DIFF
--- a/flycheck-ledger.el
+++ b/flycheck-ledger.el
@@ -38,7 +38,7 @@
   :command ("ledger" (option-flag "--pedantic" flycheck-ledger-pedantic) (eval (when (eq flycheck-ledger-pedantic 'check-payees) "--check-payees")) "-f" source-inplace "balance")
   :error-patterns
   ((error line-start "While parsing file \"" (file-name) "\", line " line ":" (zero-or-more whitespace) "\n"
-          (one-or-more line-start (or "While " "> ") (one-or-more not-newline) "\n" )
+          (zero-or-more line-start (or "While " "> ") (one-or-more not-newline) "\n" )
           (message (minimal-match (zero-or-more line-start (zero-or-more not-newline) "\n"))
                    "Error: " (one-or-more not-newline) "\n"))
    )


### PR DESCRIPTION
Error messages without intermediate "While .." lines are possible.
For example:

2013-01-01 Test
  Test 1 EUR
  Test 2 EUR
  Cash 4  ; not the missing EUR
